### PR TITLE
24 - Fix errors with related results

### DIFF
--- a/search_engine/anime_search_engine.py
+++ b/search_engine/anime_search_engine.py
@@ -55,6 +55,7 @@ class SearchEngine(object):
 		self.current_page = 1
 		self.scoring_type = "both"
 		self.word_2_vec_model = Word2Vec.load(word_2_vec_model)
+		self.model_vocab = set(self.word_2_vec_model.wv.key_to_index)
 
 		content_files = {
 			"synonyms": {"filepath": synonyms_json, "compress": False},
@@ -184,14 +185,16 @@ class SearchEngine(object):
 
 			terms = result["title"].translate(str.maketrans(
 				'', '', string.punctuation))
-			terms = list(set(terms.split()))
+			terms = terms.split()
 			if debug: print(f"Terms: {terms}")
 
 			related_terms = []
 			for term in terms:
-				similar_terms = model.most_similar(term, topn=k)
-				similar_terms.insert(0, (term, 1))
-				related_terms.append(similar_terms)
+				if term not in self.model_vocab: terms.remove(term)
+				else:
+					similar_terms = model.most_similar(term, topn=k)
+					similar_terms.insert(0, (term, 1))
+					related_terms.append(similar_terms)
 
 			indexes = [0] * len(related_terms)
 			for _ in range(k):


### PR DESCRIPTION
Fix bug where sometimes relevant results gets an error that a key is not in vocabulary.

With the bug fix it's possible that relevant results does not return anything if the titles of the top k documents only contain really infrequent words that is not in the word2vec model vocabulary. However, I'm not sure if this is possible and if it is then I think it would make sense for related results to return nothing.

Resolves #24 